### PR TITLE
FPSChartCollection

### DIFF
--- a/Source/Private/LevelStatsCollector.cpp
+++ b/Source/Private/LevelStatsCollector.cpp
@@ -37,7 +37,7 @@ void FCustomPerformanceChart::DumpFPSChartToCustomLocation( const FString & in_m
 #endif
 }
 
-FString FCustomPerformanceChart::CreateFileNameForChart( const FString &, const FString &, const FString & file_extension )
+FString FCustomPerformanceChart::CreateFileNameForChart( const FString & /* chart_type */, const FString & /* in_map_name */, const FString & file_extension )
 {
     const FString platform = FPlatformProperties::PlatformName();
     return TEXT( "metrics" ) + file_extension;

--- a/Source/Private/LevelStatsCollector.cpp
+++ b/Source/Private/LevelStatsCollector.cpp
@@ -62,8 +62,8 @@ ALevelStatsCollector::ALevelStatsCollector() :
     CaptureDelay( 0.1f ),
     CurrentRotation( 0.0f ),
     CurrentCaptureDelay( 0.0f ),
-    IsCaptureInProgress( false ),
-    IsCollectorInitialized( false )
+    bIsCapturing( false ),
+    bIsInitialized( false )
 
 {
     PrimaryActorTick.bCanEverTick = true;
@@ -90,7 +90,7 @@ void ALevelStatsCollector::Tick( const float delta_time )
 {
     Super::Tick( delta_time );
 
-    if ( !IsCaptureInProgress || !IsCollectorInitialized )
+    if ( !bIsCapturing || !bIsInitialized )
     {
         return;
     }
@@ -137,8 +137,8 @@ void ALevelStatsCollector::InitializeGrid()
 
     CurrentCellIndex = 0;
     CurrentRotation = 0.0f;
-    IsCaptureInProgress = true;
-    IsCollectorInitialized = true;
+    bIsCapturing = true;
+    bIsInitialized = true;
 
     LogGridInfo();
     ProcessNextCell();
@@ -325,7 +325,7 @@ void ALevelStatsCollector::IncrementCellIndex()
 
 void ALevelStatsCollector::FinishCapture()
 {
-    IsCaptureInProgress = false;
+    bIsCapturing = false;
     UE_LOG( LogLevelStatsCollector, Log, TEXT( "Capture process complete! Total captures: %d" ), TotalCaptureCount );
 }
 

--- a/Source/Private/LevelStatsCollector.cpp
+++ b/Source/Private/LevelStatsCollector.cpp
@@ -8,41 +8,45 @@
 #include <Engine/TextureRenderTarget2D.h>
 #include <ImageUtils.h>
 
-FCustomPerformanceChart::FCustomPerformanceChart( const FDateTime & in_start_time, const FString & in_chart_label, const FString & in_output_path ) :
-    FPerformanceTrackingChart( in_start_time, in_chart_label ),
-    CustomOutputPath( in_output_path )
+DEFINE_LOG_CATEGORY( LogLevelStatsCollector );
+
+FCustomPerformanceChart::FCustomPerformanceChart( const FDateTime & start_time, FStringView chart_label, FStringView output_path ) :
+    FPerformanceTrackingChart( start_time, FString( chart_label ) ),
+    CustomOutputPath( output_path )
 {
 }
 
-void FCustomPerformanceChart::DumpFPSChartToCustomLocation( const FString & in_map_name )
+void FCustomPerformanceChart::DumpFPSChartToCustomLocation( FStringView map_name )
 {
     TArray< const FPerformanceTrackingChart * > charts;
     charts.Add( this );
 
-    DumpChartsToOutputLog( AccumulatedChartTime, charts, in_map_name );
+    DumpChartsToOutputLog( AccumulatedChartTime, charts, FString( map_name ) );
 
 #if ALLOW_DEBUG_FILES
     IFileManager::Get().MakeDirectory( *CustomOutputPath, true );
 
     {
-        const auto log_filename = CustomOutputPath / CreateFileNameForChart( TEXT( "FPS" ), in_map_name, TEXT( ".log" ) );
-        DumpChartsToLogFile( AccumulatedChartTime, charts, in_map_name, log_filename );
+        const auto log_filename = CustomOutputPath / CreateFileNameForChart( TEXT( "FPS" ), map_name, TEXT( ".log" ) );
+        DumpChartsToLogFile( AccumulatedChartTime, charts, FString( map_name ), log_filename );
     }
 
     {
-        const auto map_and_chart_label = ChartLabel.IsEmpty() ? in_map_name : ( ChartLabel + TEXT( "-" ) + in_map_name );
-        const auto html_filename = CustomOutputPath / CreateFileNameForChart( TEXT( "FPS" ),
-                                                          *( map_and_chart_label + TEXT( "-" ) + CaptureStartTime.ToString() ),
-                                                          TEXT( ".html" ) );
+        const auto map_and_chart_label = ChartLabel.IsEmpty()
+                                             ? FString( map_name )
+                                             : FString::Printf( TEXT( "%s-%s" ), *ChartLabel, *FString( map_name ) );
+        const auto html_filename = CustomOutputPath / CreateFileNameForChart(
+                                                          TEXT( "FPS" ),
+                                                          map_name,
+                                                          FString::Printf( TEXT( "-%s.html" ), *CaptureStartTime.ToString() ) );
         DumpChartsToHTML( AccumulatedChartTime, charts, map_and_chart_label, html_filename );
     }
 #endif
 }
 
-FString FCustomPerformanceChart::CreateFileNameForChart( const FString & /* chart_type */, const FString & /* in_map_name */, const FString & file_extension )
+FString FCustomPerformanceChart::CreateFileNameForChart( FStringView, FStringView, FStringView file_extension )
 {
-    const FString platform = FPlatformProperties::PlatformName();
-    return TEXT( "metrics" ) + file_extension;
+    return FString::Printf( TEXT( "metrics%s" ), *FString( file_extension ) );
 }
 
 ALevelStatsCollector::ALevelStatsCollector() :
@@ -101,7 +105,7 @@ void ALevelStatsCollector::SetupSceneCapture() const
 {
     if ( CaptureComponent == nullptr )
     {
-        UE_LOG( LogTemp, Error, TEXT( "CaptureComponent is not set!" ) );
+        UE_LOG( LogLevelStatsCollector, Error, TEXT( "CaptureComponent is not set!" ) );
         return;
     }
 
@@ -160,7 +164,7 @@ bool ALevelStatsCollector::ProcessNextCell()
         return true;
     }
 
-    UE_LOG( LogTemp, Warning, TEXT( "Failed to find ground position for cell at %s" ), *current_cell.Center.ToString() );
+    UE_LOG( LogLevelStatsCollector, Warning, TEXT( "Failed to find ground position for cell at %s" ), *current_cell.Center.ToString() );
     CurrentCellIndex++;
     return ProcessNextCell();
 }
@@ -169,7 +173,7 @@ void ALevelStatsCollector::CaptureCurrentView()
 {
     if ( CaptureComponent == nullptr || CaptureComponent->TextureTarget == nullptr )
     {
-        UE_LOG( LogTemp, Error, TEXT( "Invalid capture component or render target!" ) );
+        UE_LOG( LogLevelStatsCollector, Error, TEXT( "Invalid capture component or render target!" ) );
         return;
     }
 
@@ -181,20 +185,20 @@ void ALevelStatsCollector::CaptureCurrentView()
     FImage image;
     if ( !FImageUtils::GetRenderTargetImage( Cast< UTextureRenderTarget >( CaptureComponent->TextureTarget ), image ) )
     {
-        UE_LOG( LogTemp, Error, TEXT( "Failed to get render target image for cell %d rotation %.0f" ), CurrentCellIndex, CurrentRotation );
+        UE_LOG( LogLevelStatsCollector, Error, TEXT( "Failed to get render target image for cell %d rotation %.0f" ), CurrentCellIndex, CurrentRotation );
         return;
     }
 
-    const auto screenshot_path = current_path + TEXT( "screenshot.png" );
+    const auto screenshot_path = FString::Printf( TEXT( "%sscreenshot.png" ), *current_path );
     if ( FImageUtils::SaveImageByExtension( *screenshot_path, image ) )
     {
         const auto & current_cell = GridCells[ CurrentCellIndex ];
-        UE_LOG( LogTemp, Log, TEXT( "Image captured at coordinates (%f, %f, %f), saved to: %s" ), current_cell.Center.X, current_cell.Center.Y, current_cell.Center.Z, *screenshot_path );
+        UE_LOG( LogLevelStatsCollector, Log, TEXT( "Image captured at coordinates (%f, %f, %f), saved to: %s" ), current_cell.Center.X, current_cell.Center.Y, current_cell.Center.Z, *screenshot_path );
         TotalCaptureCount++;
     }
     else
     {
-        UE_LOG( LogTemp, Error, TEXT( "Failed to save image: %s" ), *screenshot_path );
+        UE_LOG( LogLevelStatsCollector, Error, TEXT( "Failed to save image: %s" ), *screenshot_path );
     }
 }
 
@@ -253,7 +257,7 @@ void ALevelStatsCollector::CalculateGridBounds()
         {
             GridBounds.Max = GridBounds.Min + FVector( expected_size_x, expected_size_y, 0.0f );
 
-            UE_LOG( LogTemp, Warning, TEXT( "Grid size adjusted for cell alignment. Original: (%f, %f), Adjusted: (%f, %f)" ), actual_size_x, actual_size_y, expected_size_x, expected_size_y );
+            UE_LOG( LogLevelStatsCollector, Warning, TEXT( "Grid size adjusted for cell alignment. Original: (%f, %f), Adjusted: (%f, %f)" ), actual_size_x, actual_size_y, expected_size_x, expected_size_y );
         }
 
         GridSizeX = expected_size_x;
@@ -270,7 +274,7 @@ void ALevelStatsCollector::CalculateGridBounds()
             FVector( -half_size_x, -half_size_y, 0.0f ),
             FVector( half_size_x, half_size_y, 0.0f ) );
 
-        UE_LOG( LogTemp, Log, TEXT( "Using explicit grid dimensions: %f x %f" ), GridSizeX, GridSizeY );
+        UE_LOG( LogLevelStatsCollector, Log, TEXT( "Using explicit grid dimensions: %f x %f" ), GridSizeX, GridSizeY );
         finalize_bounds();
         return;
     }
@@ -283,7 +287,7 @@ void ALevelStatsCollector::CalculateGridBounds()
             level_bounds = level_bounds_actor->GetComponentsBoundingBox( true );
             if ( level_bounds.IsValid )
             {
-                UE_LOG( LogTemp, Log, TEXT( "Got bounds from LevelBoundsActor: %s" ), *level_bounds.ToString() );
+                UE_LOG( LogLevelStatsCollector, Log, TEXT( "Got bounds from LevelBoundsActor: %s" ), *level_bounds.ToString() );
                 finalize_bounds();
                 return;
             }
@@ -291,7 +295,7 @@ void ALevelStatsCollector::CalculateGridBounds()
     }
 
     // :NOTE: Use default area if no bounds found
-    UE_LOG( LogTemp, Warning, TEXT( "No valid bounds source found, using default 10000x10000 area" ) );
+    UE_LOG( LogLevelStatsCollector, Warning, TEXT( "No valid bounds source found, using default 10000x10000 area" ) );
     level_bounds = FBox( FVector( -5000, -5000, 0 ), FVector( 5000, 5000, 0 ) ); // Arbitrary default area
     finalize_bounds();
 }
@@ -322,7 +326,7 @@ void ALevelStatsCollector::IncrementCellIndex()
 void ALevelStatsCollector::FinishCapture()
 {
     IsCaptureInProgress = false;
-    UE_LOG( LogTemp, Log, TEXT( "Capture process complete! Total captures: %d" ), TotalCaptureCount );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "Capture process complete! Total captures: %d" ), TotalCaptureCount );
 }
 
 void ALevelStatsCollector::StartMetricsCapture()
@@ -358,32 +362,31 @@ void ALevelStatsCollector::FinishMetricsCapture()
 
 FString ALevelStatsCollector::GetBasePath() const
 {
-    const FString base_path = TEXT( "Saved/LevelStatsCollector/" );
-    return FPaths::ProjectDir() + base_path;
+    return FString::Printf( TEXT( "%sSaved/LevelStatsCollector/" ), *FPaths::ProjectDir() );
 }
 
 FString ALevelStatsCollector::GetCurrentCellPath() const
 {
-    return GetBasePath() + FString::Printf( TEXT( "Cell_%d/" ), CurrentCellIndex );
+    return FString::Printf( TEXT( "%sCell_%d/" ), *GetBasePath(), CurrentCellIndex );
 }
 
 FString ALevelStatsCollector::GetCurrentRotationPath() const
 {
-    return GetCurrentCellPath() + FString::Printf( TEXT( "Rotation_%.0f/" ), CurrentRotation );
+    return FString::Printf( TEXT( "%sRotation_%.0f/" ), *GetCurrentCellPath(), CurrentRotation );
 }
 
 void ALevelStatsCollector::LogGridInfo() const
 {
-    UE_LOG( LogTemp, Log, TEXT( "Grid Configuration:" ) );
-    UE_LOG( LogTemp, Log, TEXT( "  Bounds: Min(%s), Max(%s)" ), *GridBounds.Min.ToString(), *GridBounds.Max.ToString() );
-    UE_LOG( LogTemp, Log, TEXT( "  Dimensions: %dx%d cells" ), GridDimensions.X, GridDimensions.Y );
-    UE_LOG( LogTemp, Log, TEXT( "  Cell Size: %f" ), CellSize );
-    UE_LOG( LogTemp, Log, TEXT( "  Total Cells: %d" ), GridCells.Num() );
-    UE_LOG( LogTemp, Log, TEXT( "  Center Offset: %s" ), *GridCenterOffset.ToString() );
-    UE_LOG( LogTemp, Log, TEXT( "Camera Configuration:" ) );
-    UE_LOG( LogTemp, Log, TEXT( "  Height: %f" ), CameraHeight );
-    UE_LOG( LogTemp, Log, TEXT( "  Height Offset: %f" ), CameraHeightOffset );
-    UE_LOG( LogTemp, Log, TEXT( "  Rotation Delta: %f" ), CameraRotationDelta );
-    UE_LOG( LogTemp, Log, TEXT( "Capture Configuration:" ) );
-    UE_LOG( LogTemp, Log, TEXT( "  Capture Delay: %f" ), CaptureDelay );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "Grid Configuration:" ) );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Bounds: Min(%s), Max(%s)" ), *GridBounds.Min.ToString(), *GridBounds.Max.ToString() );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Dimensions: %dx%d cells" ), GridDimensions.X, GridDimensions.Y );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Cell Size: %f" ), CellSize );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Total Cells: %d" ), GridCells.Num() );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Center Offset: %s" ), *GridCenterOffset.ToString() );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "Camera Configuration:" ) );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Height: %f" ), CameraHeight );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Height Offset: %f" ), CameraHeightOffset );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Rotation Delta: %f" ), CameraRotationDelta );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "Capture Configuration:" ) );
+    UE_LOG( LogLevelStatsCollector, Log, TEXT( "  Capture Delay: %f" ), CaptureDelay );
 }

--- a/Source/Private/LevelStatsCollectorState.cpp
+++ b/Source/Private/LevelStatsCollectorState.cpp
@@ -26,7 +26,7 @@ void FIdleState::Enter()
 void FIdleState::Tick( const float delta_time )
 {
     CurrentDelay += delta_time;
-    if ( CurrentDelay >= Collector->GetMetricsWaitDelay() )
+    if ( CurrentDelay >= Collector->MetricsWaitDelay )
     {
         Collector->TransitionToState( MakeShared< FCapturingMetricsState >( Collector ) );
     }
@@ -53,7 +53,7 @@ void FCapturingMetricsState::Tick( const float delta_time )
 {
     CurrentCaptureTime += delta_time;
 
-    if ( CurrentCaptureTime >= Collector->GetMetricsDuration() )
+    if ( CurrentCaptureTime >= Collector->MetricsDuration )
     {
         Collector->TransitionToState( MakeShared< FWaitingForSnapshotState >( Collector ) );
     }
@@ -78,7 +78,7 @@ void FWaitingForSnapshotState::Enter()
 void FWaitingForSnapshotState::Tick( const float delta_time )
 {
     CurrentDelay += delta_time;
-    if ( CurrentDelay >= Collector->GetCaptureDelay() )
+    if ( CurrentDelay >= Collector->CaptureDelay )
     {
         Collector->CaptureCurrentView();
         Collector->TransitionToState( MakeShared< FProcessingNextRotationState >( Collector ) );
@@ -102,7 +102,7 @@ void FProcessingNextRotationState::Enter()
 
 void FProcessingNextRotationState::Tick( float delta_time )
 {
-    if ( Collector->GetCurrentRotation() >= 360.0f )
+    if ( Collector->CurrentRotation >= 360.0f )
     {
         Collector->IncrementCellIndex();
         Collector->TransitionToState( MakeShared< FProcessingNextCellState >( Collector ) );

--- a/Source/Private/LevelStatsCollectorState.cpp
+++ b/Source/Private/LevelStatsCollectorState.cpp
@@ -1,0 +1,141 @@
+﻿#include "LevelStatsCollectorState.h"
+
+#include "LevelStatsCollector.h"
+
+FLevelStatsCollectorState::FLevelStatsCollectorState( ALevelStatsCollector * collector ) :
+    Collector( collector )
+{}
+
+void FLevelStatsCollectorState::Enter()
+{}
+
+void FLevelStatsCollectorState::Exit()
+{}
+
+// :NOTE: FIdleState Implementation
+FIdleState::FIdleState( ALevelStatsCollector * collector ) :
+    FLevelStatsCollectorState( collector ),
+    CurrentDelay( 0.0f )
+{}
+
+void FIdleState::Enter()
+{
+    CurrentDelay = 0.0f;
+}
+
+void FIdleState::Tick( const float delta_time )
+{
+    CurrentDelay += delta_time;
+    if ( CurrentDelay >= Collector->GetMetricsWaitDelay() )
+    {
+        Collector->TransitionToState( MakeShared< FCapturingMetricsState >( Collector ) );
+    }
+}
+
+void FIdleState::Exit()
+{
+    CurrentDelay = 0.0f;
+}
+
+// :NOTE: FCapturingMetricsState Implementation
+FCapturingMetricsState::FCapturingMetricsState( ALevelStatsCollector * collector ) :
+    FLevelStatsCollectorState( collector ),
+    CurrentCaptureTime( 0.0f )
+{}
+
+void FCapturingMetricsState::Enter()
+{
+    CurrentCaptureTime = 0.0f;
+    Collector->StartMetricsCapture();
+}
+
+void FCapturingMetricsState::Tick( const float delta_time )
+{
+    CurrentCaptureTime += delta_time;
+
+    if ( CurrentCaptureTime >= Collector->GetMetricsDuration() )
+    {
+        Collector->TransitionToState( MakeShared< FWaitingForSnapshotState >( Collector ) );
+    }
+}
+
+void FCapturingMetricsState::Exit()
+{
+    Collector->FinishMetricsCapture();
+}
+
+// :NOTE: FWaitingForSnapshotState Implementation
+FWaitingForSnapshotState::FWaitingForSnapshotState( ALevelStatsCollector * collector ) :
+    FLevelStatsCollectorState( collector ),
+    CurrentDelay( 0.0f )
+{}
+
+void FWaitingForSnapshotState::Enter()
+{
+    CurrentDelay = 0.0f;
+}
+
+void FWaitingForSnapshotState::Tick( const float delta_time )
+{
+    CurrentDelay += delta_time;
+    if ( CurrentDelay >= Collector->GetCaptureDelay() )
+    {
+        Collector->CaptureCurrentView();
+        Collector->TransitionToState( MakeShared< FProcessingNextRotationState >( Collector ) );
+    }
+}
+
+void FWaitingForSnapshotState::Exit()
+{
+    CurrentDelay = 0.0f;
+}
+
+// :NOTE: FProcessingNextRotationState Implementation
+FProcessingNextRotationState::FProcessingNextRotationState( ALevelStatsCollector * collector ) :
+    FLevelStatsCollectorState( collector )
+{}
+
+void FProcessingNextRotationState::Enter()
+{
+    Collector->UpdateRotation();
+}
+
+void FProcessingNextRotationState::Tick( float delta_time )
+{
+    if ( Collector->GetCurrentRotation() >= 360.0f )
+    {
+        Collector->IncrementCellIndex();
+        Collector->TransitionToState( MakeShared< FProcessingNextCellState >( Collector ) );
+    }
+    else
+    {
+        Collector->TransitionToState( MakeShared< FIdleState >( Collector ) );
+    }
+}
+
+void FProcessingNextRotationState::Exit()
+{}
+
+// :NOTE: FProcessingNextCellState Implementation
+FProcessingNextCellState::FProcessingNextCellState( ALevelStatsCollector * collector ) :
+    FLevelStatsCollectorState( collector )
+{}
+
+void FProcessingNextCellState::Enter()
+{
+}
+
+void FProcessingNextCellState::Tick( float delta_time )
+{
+    if ( Collector->ProcessNextCell() )
+    {
+        Collector->TransitionToState( MakeShared< FIdleState >( Collector ) );
+    }
+    else
+    {
+        Collector->FinishCapture();
+    }
+}
+
+void FProcessingNextCellState::Exit()
+{}

--- a/Source/Public/LevelStatsCollector.h
+++ b/Source/Public/LevelStatsCollector.h
@@ -6,11 +6,6 @@
 #include "LevelStatsCollector.generated.h"
 
 class FLevelStatsCollectorState;
-class FIdleState;
-class FWaitingForSnapshotState;
-class FProcessingNextRotationState;
-class FProcessingNextCellState;
-class FCapturingMetricsState;
 
 class FCustomPerformanceChart final : public FPerformanceTrackingChart
 {

--- a/Source/Public/LevelStatsCollector.h
+++ b/Source/Public/LevelStatsCollector.h
@@ -101,6 +101,6 @@ private:
     float CurrentRotation;
     float CurrentCaptureDelay;
 
-    bool IsCaptureInProgress;
-    bool IsCollectorInitialized;
+    bool bIsCapturing;
+    bool bIsInitialized;
 };

--- a/Source/Public/LevelStatsCollector.h
+++ b/Source/Public/LevelStatsCollector.h
@@ -1,8 +1,53 @@
 ﻿#pragma once
 
+#include <ChartCreation.h>
 #include <CoreMinimal.h>
 
 #include "LevelStatsCollector.generated.h"
+
+class MAPMETRICSGENERATION_API FCustomPerformanceChart final : public FPerformanceTrackingChart
+{
+public:
+    FCustomPerformanceChart( const FDateTime & in_start_time, const FString & in_chart_label, const FString & in_output_path ) :
+        FPerformanceTrackingChart( in_start_time, in_chart_label ),
+        CustomOutputPath( in_output_path )
+    {
+    }
+
+    void DumpFPSChartToCustomLocation( const FString & in_map_name )
+    {
+        TArray< const FPerformanceTrackingChart * > charts;
+        charts.Add( this );
+
+        DumpChartsToOutputLog( AccumulatedChartTime, charts, in_map_name );
+
+#if ALLOW_DEBUG_FILES
+        IFileManager::Get().MakeDirectory( *CustomOutputPath, true );
+
+        {
+            const auto log_filename = CustomOutputPath / CreateFileNameForChart( TEXT( "FPS" ), in_map_name, TEXT( ".log" ) );
+            DumpChartsToLogFile( AccumulatedChartTime, charts, in_map_name, log_filename );
+        }
+
+        {
+            const auto map_and_chart_label = ChartLabel.IsEmpty() ? in_map_name : ( ChartLabel + TEXT( "-" ) + in_map_name );
+            const auto html_filename = CustomOutputPath / CreateFileNameForChart( TEXT( "FPS" ),
+                                                              *( map_and_chart_label + TEXT( "-" ) + CaptureStartTime.ToString() ),
+                                                              TEXT( ".html" ) );
+            DumpChartsToHTML( AccumulatedChartTime, charts, map_and_chart_label, html_filename );
+        }
+#endif
+    }
+
+private:
+    static FString CreateFileNameForChart( const FString & /* chart_type */, const FString & /* in_map_name */, const FString & file_extension )
+    {
+        const FString platform = FPlatformProperties::PlatformName();
+        return TEXT( "metrics" ) + file_extension;
+    }
+
+    FString CustomOutputPath;
+};
 
 UCLASS()
 class MAPMETRICSGENERATION_API ALevelStatsCollector final : public AActor
@@ -23,7 +68,15 @@ private:
     void CaptureCurrentView();
     TOptional< FVector > TraceGroundPosition( const FVector & start_location ) const;
     void CalculateGridBounds();
-    FString GenerateFileName() const;
+
+    void StartMetricsCapture();
+    void ProcessMetricsCapture( float DeltaTime );
+    void FinishMetricsCapture();
+
+    FString GetBasePath() const;
+    FString GetCurrentCellPath() const;
+    FString GetCurrentRotationPath() const;
+
     void LogGridInfo() const;
 
     struct FGridCell
@@ -42,8 +95,23 @@ private:
         float GroundHeight;
     };
 
+    enum class ECaptureState
+    {
+        Idle,
+        CapturingMetrics,
+        WaitingForSnapshot,
+        ProcessingNextRotation,
+        ProcessingNextCell
+    };
+
     UPROPERTY()
     USceneCaptureComponent2D * CaptureComponent;
+
+    ECaptureState CurrentState;
+    TSharedPtr< FCustomPerformanceChart > CurrentPerformanceChart;
+    float CurrentMetricsCaptureTime;
+    float MetricsDuration;
+    float MetricsWaitDelay;
 
     float GridSizeX;
     float GridSizeY;
@@ -53,7 +121,6 @@ private:
     float CameraHeightOffset;
     float CameraRotationDelta;
     float CaptureDelay;
-    FString OutputDirectory;
     TArray< FGridCell > GridCells;
     int32 CurrentCellIndex;
     float CurrentRotation;

--- a/Source/Public/LevelStatsCollector.h
+++ b/Source/Public/LevelStatsCollector.h
@@ -8,44 +8,11 @@
 class MAPMETRICSGENERATION_API FCustomPerformanceChart final : public FPerformanceTrackingChart
 {
 public:
-    FCustomPerformanceChart( const FDateTime & in_start_time, const FString & in_chart_label, const FString & in_output_path ) :
-        FPerformanceTrackingChart( in_start_time, in_chart_label ),
-        CustomOutputPath( in_output_path )
-    {
-    }
-
-    void DumpFPSChartToCustomLocation( const FString & in_map_name )
-    {
-        TArray< const FPerformanceTrackingChart * > charts;
-        charts.Add( this );
-
-        DumpChartsToOutputLog( AccumulatedChartTime, charts, in_map_name );
-
-#if ALLOW_DEBUG_FILES
-        IFileManager::Get().MakeDirectory( *CustomOutputPath, true );
-
-        {
-            const auto log_filename = CustomOutputPath / CreateFileNameForChart( TEXT( "FPS" ), in_map_name, TEXT( ".log" ) );
-            DumpChartsToLogFile( AccumulatedChartTime, charts, in_map_name, log_filename );
-        }
-
-        {
-            const auto map_and_chart_label = ChartLabel.IsEmpty() ? in_map_name : ( ChartLabel + TEXT( "-" ) + in_map_name );
-            const auto html_filename = CustomOutputPath / CreateFileNameForChart( TEXT( "FPS" ),
-                                                              *( map_and_chart_label + TEXT( "-" ) + CaptureStartTime.ToString() ),
-                                                              TEXT( ".html" ) );
-            DumpChartsToHTML( AccumulatedChartTime, charts, map_and_chart_label, html_filename );
-        }
-#endif
-    }
+    FCustomPerformanceChart( const FDateTime & in_start_time, const FString & in_chart_label, const FString & in_output_path );
+    void DumpFPSChartToCustomLocation( const FString & in_map_name );
 
 private:
-    static FString CreateFileNameForChart( const FString & /* chart_type */, const FString & /* in_map_name */, const FString & file_extension )
-    {
-        const FString platform = FPlatformProperties::PlatformName();
-        return TEXT( "metrics" ) + file_extension;
-    }
-
+    static FString CreateFileNameForChart( const FString & /* chart_type */, const FString & /* in_map_name */, const FString & file_extension );
     FString CustomOutputPath;
 };
 

--- a/Source/Public/LevelStatsCollectorCommandlet.h
+++ b/Source/Public/LevelStatsCollectorCommandlet.h
@@ -2,14 +2,14 @@
 
 #include <Commandlets/Commandlet.h>
 
-#include "PerfGrapherCommandlet.generated.h"
+#include "LevelStatsCollectorCommandlet.generated.h"
 
 UCLASS( CustomConstructor )
-class MAPMETRICSGENERATION_API UPerfGrapherCommandlet final : public UCommandlet
+class MAPMETRICSGENERATION_API ULevelStatsCollectorCommandlet final : public UCommandlet
 {
     GENERATED_BODY()
 public:
-    UPerfGrapherCommandlet();
+    ULevelStatsCollectorCommandlet();
     int32 Main( const FString & params ) override;
 
 private:
@@ -25,6 +25,6 @@ private:
         FString ScreenshotPattern;
     };
 
-    bool RunPerfGrapher( const FString & package_name, const FMetricsParams & metrics_params ) const;
+    bool RunLevelStatsCommandlet( const FString & package_name, const FMetricsParams & metrics_params ) const;
     bool ParseParams( const FString & params, FMetricsParams & out_params, TMap< FString, FString > & params_map ) const;
 };

--- a/Source/Public/LevelStatsCollectorState.h
+++ b/Source/Public/LevelStatsCollectorState.h
@@ -1,0 +1,78 @@
+﻿#pragma once
+
+#include <CoreMinimal.h>
+
+class ALevelStatsCollector;
+
+class FLevelStatsCollectorState
+{
+public:
+    explicit FLevelStatsCollectorState( ALevelStatsCollector * collector );
+    virtual ~FLevelStatsCollectorState() = default;
+
+    virtual void Enter();
+    virtual void Tick( float delta_time ) = 0;
+    virtual void Exit();
+
+protected:
+    ALevelStatsCollector * Collector;
+};
+
+class FIdleState final : public FLevelStatsCollectorState
+{
+public:
+    explicit FIdleState( ALevelStatsCollector * collector );
+
+    void Enter() override;
+    void Tick( float delta_time ) override;
+    void Exit() override;
+
+private:
+    float CurrentDelay;
+};
+
+class FWaitingForSnapshotState final : public FLevelStatsCollectorState
+{
+public:
+    explicit FWaitingForSnapshotState( ALevelStatsCollector * collector );
+
+    void Enter() override;
+    void Tick( float delta_time ) override;
+    void Exit() override;
+
+private:
+    float CurrentDelay;
+};
+
+class FProcessingNextRotationState final : public FLevelStatsCollectorState
+{
+public:
+    explicit FProcessingNextRotationState( ALevelStatsCollector * collector );
+
+    void Enter() override;
+    void Tick( float delta_time ) override;
+    void Exit() override;
+};
+
+class FProcessingNextCellState final : public FLevelStatsCollectorState
+{
+public:
+    explicit FProcessingNextCellState( ALevelStatsCollector * collector );
+
+    void Enter() override;
+    void Tick( float delta_time ) override;
+    void Exit() override;
+};
+
+class FCapturingMetricsState final : public FLevelStatsCollectorState
+{
+public:
+    explicit FCapturingMetricsState( ALevelStatsCollector * collector );
+
+    void Enter() override;
+    void Tick( float delta_time ) override;
+    void Exit() override;
+
+private:
+    float CurrentCaptureTime;
+};


### PR DESCRIPTION
Collects metrics for a set amount of time at each grid spot for each set rotation.
For now, the actor saves everything in the `Saved\LevelStatsCollector\`.

Example: 
```
-Cell_0
    -Rotation_0
         -metrics.log
         -screenshot.png
     -Rotation_90
         -metrics.log
         -screenshot.png
-Cell_1
    -Rotation_0
         -metrics.log
         -screenshot.png
     -Rotation_90
         -metrics.log
         -screenshot.png
```